### PR TITLE
added API proxy to handle server-side cookie setting

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,17 @@
+import axios from "axios"
+import { NextRequest, NextResponse } from "next/server"
+
+interface AuthCredentials {
+    accessToken : string
+    refreshToken : string
+}
+
+export const POST = async (req : Request) => {
+    const reqBody = await req.json()
+    console.log(reqBody);
+    const ret = await (await axios.post("http://localhost:8080/auth/login",reqBody)).data
+    const res = new NextResponse();
+    res.cookies.set("accessToken",ret.accessToken);
+    res.cookies.set("refreshToken",ret.refreshToken);
+    return res
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -85,7 +85,7 @@ export default function LoginScreen({ onBack, onLogin, onForgotPassword }: Login
 
       console.log("Sending payload:", payload);
 
-      const response = await axios.post("http://localhost:8080/auth/login", payload);
+      const response = await axios.post("/api/auth/login", payload);
 
       console.log("Login successful:", response.data);
       


### PR DESCRIPTION
Current problem is that, the authentication flow need to be crafted neatly as there is a server-side cookie setting flow which require us to process the request on the server-side and current approach is calling the request with the client side . In this case the server can't perform a stateless authentication . Hence, the cookie is not set and other locked routes can't be used. Easiest way to fix this is to create a proxied API as I did in this pull request. This code was tested with the login page and is working perfectly fine.